### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,8 @@
 name: "Test"
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/suasuasuasuasua/phys/security/code-scanning/1](https://github.com/suasuasuasuasua/phys/security/code-scanning/1)

In general, the fix is to explicitly set GITHUB_TOKEN permissions to the minimum needed, either at the workflow root or on the individual job. Since this workflow has just one job and does not perform any write operations against the GitHub API, we can safely restrict token permissions to read-only repository contents.

The best way to fix this without changing existing functionality is to add a `permissions` block at the workflow root (near the top, after `name:` and before `on:`) that sets `contents: read`. None of the existing steps (`actions/checkout`, `actions/setup-python`, `pip install`, `python setup.py install/test`) require write permissions to the repository via the GitHub API, so this change will not affect behavior.

Concretely, in `.github/workflows/test.yaml`, insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: "Test"`) and line 3 (`on:`). No other imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
